### PR TITLE
use context manager to avoid unclosed files

### DIFF
--- a/py3dtiles/tile.py
+++ b/py3dtiles/tile.py
@@ -23,9 +23,8 @@ class Tile(ABC):
 
     def save_as(self, filename):
         tile_arr = self.to_array()
-        f = open(filename, 'bw')
-        f.write(bytes(tile_arr))
-        f.close()
+        with open(filename, 'bw') as f:
+            f.write(bytes(tile_arr))
 
     def sync(self):
         """

--- a/tests/test_b3dm.py
+++ b/tests/test_b3dm.py
@@ -21,16 +21,16 @@ class TestTileReader(unittest.TestCase):
         self.assertEqual(tile.header.bt_json_byte_length, 0)
         self.assertEqual(tile.header.bt_bin_byte_length, 0)
 
-        f = open('tests/dragon_low_gltf_header.json', 'r')
-        gltf_header = json.loads(f.read())
+        with open('tests/dragon_low_gltf_header.json', 'r') as f:
+            gltf_header = json.loads(f.read())
         self.assertDictEqual(gltf_header, tile.body.glTF.header)
 
 
 class TestTileBuilder(unittest.TestCase):
 
     def test_build(self):
-        f = open('tests/building.wkb', 'rb')
-        wkb = f.read()
+        with open('tests/building.wkb', 'rb') as f:
+            wkb = f.read()
 
         box = [[-8.74748499994166, -7.35523200035095, -2.05385796777344],
                [8.8036420000717, 7.29930999968201, 2.05386103222656]]


### PR DESCRIPTION
causes warning generated by py.test:
=================================== warnings summary ====================================
tests/test_b3dm.py::TestTileReader::test_read
  /usr/lib/python3.5/unittest/case.py:601: ResourceWarning: unclosed file <_io.TextIOWrapper name='tests/dragon_low_gltf_header.json' mode='r' encoding='UTF-8'>
    testMethod()

tests/test_b3dm.py::TestTileBuilder::test_build
  /usr/lib/python3.5/unittest/case.py:601: ResourceWarning: unclosed file <_io.BufferedReader name='tests/building.wkb'>
    testMethod()