### PR TITLE
fix: select reliably triangulation projection plane and orientation

### DIFF
--- a/py3dtiles/wkb_utils.py
+++ b/py3dtiles/wkb_utils.py
@@ -178,9 +178,16 @@ def triangulate(polygon, additionalPolygons=[]):
     """
     Triangulates 3D polygons
     """
-    vect1 = polygon[0][1] - polygon[0][0]
-    vect2 = polygon[0][2] - polygon[0][0]
-    vectProd = np.cross(vect1, vect2)
+    vectProd = np.array([0, 0, 0], dtype=np.float32)
+    for i in range(len(polygon[0])):
+        vect1 = (polygon[0][(i) % len(polygon[0])] -
+                 polygon[0][(i+1) % len(polygon[0])])
+        vect2 = (polygon[0][(i) % len(polygon[0])] -
+                 polygon[0][(i-1) % len(polygon[0])])
+        vect1 /= np.linalg.norm(vect1)
+        vect2 /= np.linalg.norm(vect2)
+        vectProd += np.cross(vect1, vect2)
+
     polygon2D = []
     holes = []
     delta = 0


### PR DESCRIPTION
In some cases, the first triangle is not enough to determine the projection plane or can give the wrong triangle orientation.