### PR TITLE
Use psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = (
     'pyproj',
     'cython',
     'triangle',
-    'psycopg2'
+    'psycopg2-binary'
 )
 
 dev_requirements = (


### PR DESCRIPTION
psycopg2, as a package name, is deprecated. psycopg2-binary should be used instead.