### PR TITLE
fix(packaging): use zip_safe=False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,5 +83,6 @@ setup(
     },
     entry_points={
         'console_scripts': ['py3dtiles=py3dtiles.command_line:main'],
-    }
+    },
+    zip_safe=False  # zip packaging conflicts with Numba cache (#25)
 )


### PR DESCRIPTION
Numba caching strategy seems to be incompatible with zip storage of source files.
Using zip_safe=False fix this problem.

Fixes #25 

