### PR TITLE
docs: fix a 404 url

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,7 +22,7 @@ Point Cloud
 ~~~~~~~~~~~
 
 Points Tile Format:
-https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/TileFormats/PointCloud
+https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification/TileFormats/PointCloud
 
 In the current implementation, the *Pnts* class only contains a *FeatureTable*
 (*FeatureTableHeader* and a *FeatureTableBody*, which contains features of type


### PR DESCRIPTION
There is a wrong URL address in API doc, probably coming from a 3d-tiles repo modification.

This PR fixes it.