### PR TITLE
Semantic change: Tile -> TileContent

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,11 +8,11 @@ Generic Tile
 The py3dtiles module provides some classes to fit into the
 specification:
 
-- *Tile* with a header *TileHeader* and a body *TileBody*
+- *TileContent* with a header *TileHeader* and a body *TileBody*
 - *TileHeader* represents the metadata of the tile (magic value, version, ...)
 - *TileBody* contains varying semantic and geometric data depending on the the tile's type
 
-Moreover, a utility class *TileReader* is available to read a tile
+Moreover, a utility class *TileContentReader* is available to read a tile
 file as well as a simple command line tool to retrieve basic information
 about a tile: **py3dtiles\_info**. We also provide a utility to generate a
 tileset from a list of 3D models in WKB format or stored in a postGIS table.
@@ -32,20 +32,20 @@ In the current implementation, the *Pnts* class only contains a *FeatureTable*
 
 .. code-block:: python
 
-    >>> from py3dtiles import TileReader
+    >>> from py3dtiles import TileContentReader
     >>> from py3dtiles import Pnts
     >>>
     >>> filename = 'tests/pointCloudRGB.pnts'
     >>>
     >>> # read the file
-    >>> tile = TileReader().read_file(filename)
+    >>> tile_content = TileContentReader.read_file(filename)
     >>>
-    >>> # tile is an instance of the Tile class
-    >>> tile
-    <py3dtiles.tile.Tile>
+    >>> # tile_content is an instance of the TileContent class
+    >>> tile_content
+    <py3dtiles.tile.TileContent>
     >>>
-    >>> # extract information about the tile header
-    >>> th = tile.header
+    >>> # extract information about the tile_content header
+    >>> th = tile_content.header
     >>> th
     <py3dtiles.tile.TileHeader>
     >>> th.magic_value
@@ -54,7 +54,7 @@ In the current implementation, the *Pnts* class only contains a *FeatureTable*
     15176
     >>>
     >>> # extract the feature table
-    >>> ft = tile.body.feature_table
+    >>> ft = tile_content.body.feature_table
     >>> ft
     <py3dtiles.feature_table.FeatureTable
     >>>
@@ -116,17 +116,17 @@ https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/TileFormats/Batche
 
 .. code-block:: python
 
-    >>> from py3dtiles import TileReader
+    >>> from py3dtiles import TileContentReader
     >>> from py3dtiles import B3dm
     >>>
     >>> filename = 'tests/dragon_low.b3dm'
     >>>
     >>> # read the file
-    >>> tile = TileReader().read_file(filename)
+    >>> tile_content = TileContentReader.read_file(filename)
     >>>
-    >>> # tile is an instance of the Tile class
-    >>> tile
-    <py3dtiles.tile.Tile>
+    >>> # tile_content is an instance of the TileContent class
+    >>> tile_content
+    <py3dtiles.tile.TileContent>
     >>>
     >>> # extract information about the tile header
     >>> th = tile.header
@@ -138,7 +138,7 @@ https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/TileFormats/Batche
     47246
     >>>
     >>> # extract the glTF
-    >>> gltf = tile.body.glTF
+    >>> gltf = tile_content.body.glTF
     >>> gltf
     <py3dtiles.gltf.GlTF>
     >>>
@@ -181,7 +181,7 @@ file containing polyhedralsurfaces or multipolygons.
     >>> geometry = { 'position': positions, 'normal': normals, 'bbox': box }
     >>> gltf = GlTF.from_binary_arrays([geometry], transform)
     >>>
-    >>> # create a b3dm tile directly from the glTF.
+    >>> # create a b3dm tile_content directly from the glTF.
     >>> t = B3dm.from_glTF(glTF)
     >>>
     >>> # to save our tile as a .b3dm file

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,7 +4,7 @@ Command line usage
 info
 ~~~~
 
-Here is an example on how to retrieve basic information about a tile, in this
+Here is an example on how to retrieve basic information about a tile binary content, in this
 case *pointCloudRGB.pnts*:
 
 .. code-block:: shell

--- a/py3dtiles/__init__.py
+++ b/py3dtiles/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from .utils import TileReader, convert_to_ecef
-from .tile import Tile
+from .utils import TileContentReader, convert_to_ecef
+from .tile import TileContent
 from .feature_table import Feature
 from .gltf import GlTF
 from .pnts import Pnts
@@ -10,5 +10,5 @@ from .batch_table import BatchTable
 from .wkb_utils import TriangleSoup
 
 __version__ = '1.1.0'
-__all__ = ['TileReader', 'convert_to_ecef', 'Tile', 'Feature', 'GlTF', 'Pnts',
+__all__ = ['TileContentReader', 'convert_to_ecef', 'TileContent', 'Feature', 'GlTF', 'Pnts',
            'B3dm', 'BatchTable', 'TriangleSoup']

--- a/py3dtiles/__init__.py
+++ b/py3dtiles/__init__.py
@@ -9,6 +9,6 @@ from .b3dm import B3dm
 from .batch_table import BatchTable
 from .wkb_utils import TriangleSoup
 
-__version__ = '1.1.0'
+__version__ = '2.0.0'
 __all__ = ['TileContentReader', 'convert_to_ecef', 'TileContent', 'Feature', 'GlTF', 'Pnts',
            'B3dm', 'BatchTable', 'TriangleSoup']

--- a/py3dtiles/b3dm.py
+++ b/py3dtiles/b3dm.py
@@ -1,13 +1,13 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 import struct
 import numpy as np
 
-from .tile import Tile, TileHeader, TileBody, TileType
+from .tile import TileContent, TileHeader, TileBody, TileType
 from .gltf import GlTF
 from .batch_table import BatchTable
 
 
-class B3dm(Tile):
+class B3dm(TileContent):
 
     @staticmethod
     def from_glTF(gltf, bt=None):
@@ -22,7 +22,7 @@ class B3dm(Tile):
 
         Returns
         -------
-        tile : Tile
+        tile : TileContent
         """
 
         tb = B3dmBody()
@@ -32,7 +32,7 @@ class B3dm(Tile):
         th = B3dmHeader()
         th.sync(tb)
 
-        t = Tile()
+        t = TileContent()
         t.body = tb
         t.header = th
 
@@ -47,7 +47,7 @@ class B3dm(Tile):
 
         Returns
         -------
-        t : Tile
+        t : TileContent
         """
 
         # build tile header
@@ -62,8 +62,8 @@ class B3dm(Tile):
                  - B3dmHeader.BYTELENGTH])
         b = B3dmBody.from_array(h, b_arr)
 
-        # build Tile with header and body
-        t = Tile()
+        # build TileContent with header and body
+        t = TileContent()
         t.header = h
         t.body = b
 

--- a/py3dtiles/convert.py
+++ b/py3dtiles/convert.py
@@ -16,7 +16,7 @@ import argparse
 from py3dtiles.points.transformations import rotation_matrix, angle_between_vectors, vector_product, inverse_matrix, scale_matrix, translation_matrix
 from py3dtiles.points.utils import compute_spacing, name_to_filename
 from py3dtiles.points.node import Node
-from py3dtiles import TileReader
+from py3dtiles import TileContentReader
 from py3dtiles.points.shared_node_store import SharedNodeStore
 import py3dtiles.points.task.las_reader as las_reader
 import py3dtiles.points.task.xyz_reader as xyz_reader
@@ -41,11 +41,11 @@ def write_tileset(in_folder, out_folder, octree_metadata, offset, scale, project
         for child in ['0', '1', '2', '3', '4', '5', '6', '7']:
             ondisk_tile = name_to_filename(out_folder, child.encode('ascii'), '.pnts')
             if os.path.exists(ondisk_tile):
-                tile = TileReader().read_file(ondisk_tile)
-                fth = tile.body.feature_table.header
-                xyz = tile.body.feature_table.body.positions_arr.view(np.float32).reshape((fth.points_length, 3))
+                tile_content = TileContentReader.read_file(ondisk_tile)
+                fth = tile_content.body.feature_table.header
+                xyz = tile_content.body.feature_table.body.positions_arr.view(np.float32).reshape((fth.points_length, 3))
                 if include_rgb:
-                    rgb = tile.body.feature_table.body.colors_arr.reshape((fth.points_length, 3))
+                    rgb = tile_content.body.feature_table.body.colors_arr.reshape((fth.points_length, 3))
                 else:
                     rgb = np.zeros(xyz.shape, dtype=np.uint8)
 

--- a/py3dtiles/info.py
+++ b/py3dtiles/info.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from py3dtiles import TileReader
+from py3dtiles import TileContentReader
 
 
 def print_pnts_info(tile):
@@ -53,7 +53,7 @@ def print_b3dm_info(tile):
 
 
 def main(args):
-    tile = TileReader().read_file(args.filename)
+    tile = TileContentReader.read_file(args.filename)
     magic = tile.header.magic_value
 
     if magic == "pnts":

--- a/py3dtiles/merger.py
+++ b/py3dtiles/merger.py
@@ -2,7 +2,7 @@ import sys
 import os
 import numpy as np
 import json
-from py3dtiles import TileReader
+from py3dtiles import TileContentReader
 from py3dtiles.points.utils import split_aabb
 from py3dtiles.points.transformations import inverse_matrix
 from py3dtiles.points.task.pnts_writer import points_to_pnts
@@ -16,7 +16,7 @@ def _get_root_tile(tileset, filename):
         folder,
         tileset['root']['content']['uri'])
 
-    return TileReader().read_file(pnts_filename)
+    return TileContentReader.read_file(pnts_filename)
 
 
 def _get_root_transform(tileset):

--- a/py3dtiles/pnts.py
+++ b/py3dtiles/pnts.py
@@ -2,11 +2,11 @@
 import struct
 import numpy as np
 
-from .tile import Tile, TileHeader, TileBody, TileType
+from .tile import TileContent, TileHeader, TileBody, TileType
 from .feature_table import FeatureTable
 
 
-class Pnts(Tile):
+class Pnts(TileContent):
 
     @staticmethod
     def from_features(pdtype, cdtype, features):
@@ -20,7 +20,7 @@ class Pnts(Tile):
 
         Returns
         -------
-        tile : Tile
+        tile : TileContent
         """
 
         ft = FeatureTable.from_features(pdtype, cdtype, features)
@@ -30,7 +30,7 @@ class Pnts(Tile):
 
         th = PntsHeader()
 
-        t = Tile()
+        t = TileContent()
         t.body = tb
         t.header = th
 
@@ -45,7 +45,7 @@ class Pnts(Tile):
 
         Returns
         -------
-        t : Tile
+        t : TileContent
         """
 
         # build tile header
@@ -60,8 +60,8 @@ class Pnts(Tile):
         b_arr = array[PntsHeader.BYTELENGTH:PntsHeader.BYTELENGTH + b_len]
         b = PntsBody.from_array(h, b_arr)
 
-        # build Tile with header and body
-        t = Tile()
+        # build TileContent with header and body
+        t = TileContent()
         t.header = h
         t.body = b
 

--- a/py3dtiles/points/node.py
+++ b/py3dtiles/points/node.py
@@ -3,7 +3,7 @@ from pickle import dumps as pdumps, loads as ploads
 import os
 import json
 
-from py3dtiles import TileReader
+from py3dtiles import TileContentReader
 from py3dtiles.feature_table import SemanticPoint
 from py3dtiles.points.utils import name_to_filename, node_from_name, SubdivisionType, aabb_size_to_subdivision_type
 from py3dtiles.points.points_grid import Grid
@@ -194,7 +194,7 @@ class Node(object):
         #   - computing the real AABB (instead of the one based on the octree)
         #   - merging this tile's small (<100 points) children
         if os.path.exists(ondisk_tile):
-            tile = TileReader().read_file(ondisk_tile)
+            tile = TileContentReader.read_file(ondisk_tile)
             fth = tile.body.feature_table.header
             xyz = tile.body.feature_table.body.positions_arr
             if fth.colors != SemanticPoint.NONE:
@@ -222,7 +222,7 @@ class Node(object):
                 # See if we should merge this child in tile
                 if xyz is not None:
                     # Read pnts content
-                    tile = TileReader().read_file(child_ondisk_tile)
+                    tile = TileContentReader.read_file(child_ondisk_tile)
                     fth = tile.body.feature_table.header
 
                     # If this child is small enough, merge in the current tile

--- a/py3dtiles/points/task/pnts_writer.py
+++ b/py3dtiles/points/task/pnts_writer.py
@@ -33,7 +33,7 @@ def points_to_pnts(name, points, out_folder, include_rgb):
     body = py3dtiles.pnts.PntsBody()
     body.feature_table = ft
 
-    tile = py3dtiles.tile.Tile()
+    tile = py3dtiles.tile.TileContent()
     tile.body = body
     tile.header = py3dtiles.pnts.PntsHeader()
     tile.header.sync(body)

--- a/py3dtiles/tile.py
+++ b/py3dtiles/tile.py
@@ -5,7 +5,7 @@ from enum import Enum
 from abc import ABC, abstractmethod
 
 
-class Tile(ABC):
+class TileContent(ABC):
 
     def __init__(self):
         self.header = None

--- a/py3dtiles/utils.py
+++ b/py3dtiles/utils.py
@@ -12,16 +12,18 @@ def convert_to_ecef(x, y, z, epsg_input):
     return pyproj.transform(inp, outp, x, y, z)
 
 
-class TileReader(object):
+class TileContentReader(object):
 
-    def read_file(self, filename):
+    @staticmethod
+    def read_file(filename):
         with open(filename, 'rb') as f:
             data = f.read()
             arr = np.frombuffer(data, dtype=np.uint8)
-            return self.read_array(arr)
+            return TileContentReader.read_array(arr)
         return None
 
-    def read_array(self, array):
+    @staticmethod
+    def read_array(array):
         magic = ''.join([c.decode('UTF-8') for c in array[0:4].view('c')])
         if magic == 'pnts':
             return Pnts.from_array(array)

--- a/tests/test_b3dm.py
+++ b/tests/test_b3dm.py
@@ -2,17 +2,16 @@
 
 import unittest
 import numpy as np
-import binascii
 import json
 # np.set_printoptions(formatter={'int':hex})
 
-from py3dtiles import TileReader, Tile, Feature, B3dm, GlTF, TriangleSoup
+from py3dtiles import TileContentReader, B3dm, GlTF, TriangleSoup
 
 
-class TestTileReader(unittest.TestCase):
+class TestTileContentReader(unittest.TestCase):
 
     def test_read(self):
-        tile = TileReader().read_file('tests/dragon_low.b3dm')
+        tile = TileContentReader().read_file('tests/dragon_low.b3dm')
 
         self.assertEqual(tile.header.version, 1.0)
         self.assertEqual(tile.header.tile_byte_length, 47246)
@@ -26,7 +25,7 @@ class TestTileReader(unittest.TestCase):
         self.assertDictEqual(gltf_header, tile.body.glTF.header)
 
 
-class TestTileBuilder(unittest.TestCase):
+class TestTileContentBuilder(unittest.TestCase):
 
     def test_build(self):
         with open('tests/building.wkb', 'rb') as f:
@@ -53,7 +52,7 @@ class TestTileBuilder(unittest.TestCase):
         t = B3dm.from_glTF(glTF)
 
         # get an array
-        tile_arr = t.to_array()
+        t.to_array()
         self.assertEqual(t.header.version, 1.0)
         self.assertEqual(t.header.tile_byte_length, 2952)
         self.assertEqual(t.header.ft_json_byte_length, 0)
@@ -62,6 +61,7 @@ class TestTileBuilder(unittest.TestCase):
         self.assertEqual(t.header.bt_bin_byte_length, 0)
 
         # t.save_as("/tmp/py3dtiles_test_build_1.b3dm")
+
 
 class TestTexturedTileBuilder(unittest.TestCase):
 
@@ -93,7 +93,7 @@ class TestTexturedTileBuilder(unittest.TestCase):
         t = B3dm.from_glTF(glTF)
 
         # get an array
-        tile_arr = t.to_array()
+        t.to_array()
         self.assertEqual(t.header.version, 1.0)
         self.assertEqual(t.header.tile_byte_length, 1556)
         self.assertEqual(t.header.ft_json_byte_length, 0)

--- a/tests/test_pc.py
+++ b/tests/test_pc.py
@@ -4,13 +4,13 @@ import unittest
 import numpy as np
 # np.set_printoptions(formatter={'int':hex})
 
-from py3dtiles import TileReader, Tile, Feature, Pnts
+from py3dtiles import TileContentReader, Feature, Pnts
 
 
-class TestTileReader(unittest.TestCase):
+class TestTileContentReader(unittest.TestCase):
 
     def test_read(self):
-        tile = TileReader().read_file('tests/pointCloudRGB.pnts')
+        tile = TileContentReader().read_file('tests/pointCloudRGB.pnts')
 
         self.assertEqual(tile.header.version, 1.0)
         self.assertEqual(tile.header.tile_byte_length, 15176)
@@ -28,7 +28,7 @@ class TestTileReader(unittest.TestCase):
 class TestTileBuilder(unittest.TestCase):
 
     def test_build_without_colors(self):
-        tread = TileReader().read_file('tests/pointCloudRGB.pnts')
+        tread = TileContentReader().read_file('tests/pointCloudRGB.pnts')
         f0_ref = tread.body.feature_table.feature(0).positions
 
         # numpy dtype for positions and colors
@@ -68,7 +68,7 @@ class TestTileBuilder(unittest.TestCase):
         self.assertAlmostEqual(f0_ref['Z'], f0['Z'])
 
     def test_build(self):
-        tread = TileReader().read_file('tests/pointCloudRGB.pnts')
+        tread = TileContentReader().read_file('tests/pointCloudRGB.pnts')
 
         # numpy dtype for positions and colors
         pdt = np.dtype([('X', '<f4'), ('Y', '<f4'), ('Z', '<f4')])


### PR DESCRIPTION
This PR renames Tile into TileContent and TileReader into TileContentReader.

Rationale: in 3dtiles, the tile is the json containing a geometricError, a boundingVolume, a content etc... Whereas the *content* is the tile binary content (i3dm, b3dm). Py3dtiles uses Tile when refering to TileContent.